### PR TITLE
Optimize Docker cross-compilation

### DIFF
--- a/src/SecretsMocker/SecretsMocker/Dockerfile
+++ b/src/SecretsMocker/SecretsMocker/Dockerfile
@@ -1,16 +1,10 @@
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-
+ARG TARGETARCH
 WORKDIR '/src/SecretsMocker/SecretsMocker'
 COPY . .
-RUN dotnet restore './SecretsMocker.csproj'
-RUN dotnet build './SecretsMocker.csproj' -c Release -o /app/build --no-restore
-
-FROM build AS publish
-
-RUN dotnet publish './SecretsMocker.csproj' --no-restore -c Release -o /app/publish /p:UseAppHost=false --self-contained false
+RUN dotnet publish './SecretsMocker.csproj' -o /app/publish --arch $TARGETARCH
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 as final
-
 WORKDIR /app
-COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "SecretsMocker.dll"]
+COPY --from=build /app/publish .
+ENTRYPOINT ["./SecretsMocker"]


### PR DESCRIPTION
Since the SDK can cross-compile with ease, we really only need N+1 images to build N architectures:

* 1 image for the SDK, can be any architecture
* N dotnet/aspnet:8.0 images, one for each target architecture

This set of changes

* uses the host platform for the SDK build container
* tells the SDK to publish for each target architecture, optimized for that architecture
* copies that result into a final build container

